### PR TITLE
Fix conversation status toggle

### DIFF
--- a/woot/actions.py
+++ b/woot/actions.py
@@ -1,9 +1,7 @@
-""" All actions for resources are defined here. """
+"""All actions for resources are defined here."""
 
-from typing import Any, Optional, Union, Type
 from dataclasses import dataclass, field
-from typing import Callable
-
+from typing import Any, Callable, Optional, Type, Union
 
 import woot.schema as ws
 
@@ -357,6 +355,7 @@ class ConversationsActions:
         default_factory=lambda: action_factory(
             method="POST",
             url="api/v1/accounts/{account_id}/conversations/{conversation_id}/toggle_status",
+            schema_=ws.ConversationStatusToggle,
         )
     )
 

--- a/woot/schema.py
+++ b/woot/schema.py
@@ -1,4 +1,4 @@
-""" Schema for the action request body. Woot, woot. """
+"""Schema for the action request body. Woot, woot."""
 
 from __future__ import annotations
 
@@ -457,8 +457,7 @@ class Payload:
 
 @dataclass
 class ConversationStatusToggle:
-    meta: Optional[Dict[str, Any]] = None
-    payload: Optional[Payload] = None
+    status: Status
 
 
 @dataclass


### PR DESCRIPTION
The action for https://www.chatwoot.com/developers/api/#tag/Conversations/operation/toggle-status-of-a-conversation
previously failed due to having no defined schema.

This PR fixes the issue.